### PR TITLE
Harden upstream sync workflow

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,79 @@
+name: Sync fork and update AI list
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get repository information
+        id: repo
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.repos.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            core.setOutput('default_branch', data.default_branch);
+
+            if (!data.parent) {
+              core.setFailed('Repository does not have an upstream parent to sync from.');
+              return;
+            }
+
+            core.setOutput('parent', data.parent.full_name);
+            core.setOutput('parent_default_branch', data.parent.default_branch);
+            core.info(`Syncing with ${data.parent.full_name}`);
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.repo.outputs.default_branch }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Configure Git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync from upstream
+        env:
+          UPSTREAM_REPOSITORY: ${{ steps.repo.outputs.parent }}
+          UPSTREAM_BRANCH: ${{ steps.repo.outputs.parent_default_branch }}
+          DEFAULT_BRANCH: ${{ steps.repo.outputs.default_branch }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git remote remove upstream 2>/dev/null || true
+          git remote add upstream https://x-access-token:${GITHUB_TOKEN}@github.com/${UPSTREAM_REPOSITORY}.git
+          git fetch upstream ${UPSTREAM_BRANCH}
+          git checkout ${DEFAULT_BRANCH}
+          git merge --ff-only upstream/${UPSTREAM_BRANCH}
+
+      - name: Generate ai.txt from chatgpt.list
+        run: python3 scripts/convert_chatgpt_to_ai.py
+
+      - name: Commit updated ruleset
+        run: |
+          if ! git diff --quiet; then
+            git add ai.txt
+            git commit -m "chore: sync upstream and update ai list"
+          fi
+
+      - name: Push changes
+        env:
+          DEFAULT_BRANCH: ${{ steps.repo.outputs.default_branch }}
+        run: git push origin ${DEFAULT_BRANCH}

--- a/ai.txt
+++ b/ai.txt
@@ -29,6 +29,7 @@ payload:
   - '+.oaistatic.com'
   - '+.deepmind.com'
   - '+.chatgpt.com'
+  - '+.notebooklm.google.com'
   - '+.makersuite.google.com'
   - '+.alkalicore-pa.clients6.google.com'
   - '+.aistudio.google.com'

--- a/scripts/convert_chatgpt_to_ai.py
+++ b/scripts/convert_chatgpt_to_ai.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Convert chatgpt.list rules into the Clash rule-set format."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+RULE_PREFIX_TYPES = {"DOMAIN", "DOMAIN-SUFFIX", "DOMAIN-KEYWORD"}
+
+
+def parse_rules(lines: Iterable[str]) -> list[str]:
+    """Parse rules from the chatgpt.list format into payload entries.
+
+    Empty lines and comments are ignored. Duplicate entries are skipped while
+    keeping the original order of the remaining rules.
+    """
+
+    entries: list[str] = []
+    seen: set[str] = set()
+
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        try:
+            rule_type, value = (part.strip() for part in line.split(",", 1))
+        except ValueError as exc:  # pragma: no cover - defensive guard
+            raise ValueError(f"Invalid rule line: {raw_line!r}") from exc
+
+        if not value:
+            continue
+
+        if rule_type in RULE_PREFIX_TYPES:
+            entry = f"+.{value}"
+        else:
+            entry = value
+
+        if entry not in seen:
+            seen.add(entry)
+            entries.append(entry)
+
+    return entries
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    source = repo_root / "chatgpt.list"
+    target = repo_root / "ai.txt"
+
+    payload_entries = parse_rules(source.read_text(encoding="utf-8").splitlines())
+
+    output_lines = ["payload:"] + [f"  - '{entry}'" for entry in payload_entries]
+    target.write_text("\n".join(output_lines) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- authenticate upstream fetches in the sync workflow so private parents can be mirrored
- invoke the converter with python3 and explicitly stage ai.txt before committing changes

## Testing
- python3 scripts/convert_chatgpt_to_ai.py

------
https://chatgpt.com/codex/tasks/task_e_68cace81dd00832f939fecdedd2bf41f